### PR TITLE
fix: Adjust z-index to prevent un-clickable header links 

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -215,7 +215,7 @@ main > div > .white-fade {
 
 .loading-dots {
   animation: dots 0.5s linear infinite;
-  coloer: #0657F9
+  color: #0657F9
 }
 
 @keyframes dots {
@@ -306,7 +306,6 @@ footer > div > input {
   box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.16);
   position: relative;
   font-size: 16px;
-  placeholder-color: #9D9D9D;
 }
 
 footer > div > input::placeholder { 

--- a/src/App.css
+++ b/src/App.css
@@ -58,6 +58,7 @@ pre > p {
 /* Header */
 
 header {
+  z-index: 1;
   width: 60%;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Description

This PR has the purpose of fixing the header links. Currently it's not always possible to click the link text.

This appears to happen because the link text gets hidden behind other elements. This is very apparent when you make the screen a little smaller since the main elements completely block the ability to click the header links. Adjusting the z-index was the first thing that came to my mind and it appears to work.

Extra: 
* Also fixed two warnings associated with a typo and a css property that was not being used

## Motivation and Context

The motivation is to correct what appears to be a small issue that can block user from being able to properly click header links, especially when the screen size is small. 

## How Has This Been Tested?

After making the changes I ran `yarn run start`  and confirmed that everything appeared as expected.

## Screenshots (if appropriate):